### PR TITLE
Bugfix for dashboard summary, item transactions

### DIFF
--- a/backend/routes/dashboard.js
+++ b/backend/routes/dashboard.js
@@ -114,10 +114,10 @@ router.get('/budget/:user_id', function (req, res, next) {
   ])
     .then((items) => {
       console.log({ items });
-      const total = {
-        total: parseFloat(items[0].total)
+      const spent = {
+        spent: parseFloat(items[0].total)
       }
-      res.send(total);
+      res.send(spent);
     })
     .catch((err) => {
       console.log({ err });

--- a/src/components/ReceiptUploadedPage/Receipt.js
+++ b/src/components/ReceiptUploadedPage/Receipt.js
@@ -13,9 +13,9 @@ function Receipt(props) {
             {...provided.droppableProps}
             ref={provided.innerRef}
           >
-            {items.map(({ itemId, itemName, price, quantity }, index) => {
+            {items.map(({ name, price, qty }, index) => {
               return (
-                <Draggable key={itemId} draggableId={itemId} index={index}>
+                <Draggable key={index} draggableId={name} index={index}>
                   {(provided) => (
                     <li
                       ref={provided.innerRef}
@@ -24,13 +24,13 @@ function Receipt(props) {
                     >
                       <div className="item">
                         <div className="itemName">
-                          <p>{itemName}</p>
+                          <p>{name}</p>
                         </div>
                         <div className="price">
                           <p>{price}</p>
                         </div>
                         <div className="quantity">
-                          <p>{quantity}</p>
+                          <p>{qty}</p>
                         </div>
                       </div>
                     </li>

--- a/src/components/ReceiptUploadedPage/ReceiptUploadedPage.js
+++ b/src/components/ReceiptUploadedPage/ReceiptUploadedPage.js
@@ -13,7 +13,7 @@ import {
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { useEffect } from "react";
 
-function ReceiptUploadedPage() {
+function ReceiptUploadedPage(props) {
   const dispatch = useDispatch();
   const user_id = useSelector((state) => state.global.user._id);
   const categories = useSelector((state) => state.categories.categories);
@@ -51,7 +51,7 @@ function ReceiptUploadedPage() {
       quantity: "Qty: 1",
     },
   ];
-  const [items, updateItems] = useState(transactions);
+  const [items, updateItems] = useState(props.items);
 
   useEffect(() => {
     if (categoriesStatus === "idle") {

--- a/src/features/dashboardSlice.js
+++ b/src/features/dashboardSlice.js
@@ -35,7 +35,7 @@ const dashboardSlice = createSlice({
   extraReducers: {
     [fetchSummary.fulfilled]: (state, action) => {
       console.log(current(state), { action })
-      state.spentForWeek = action.payload.total || 0
+      state.spentForWeek = action.payload.spent || 0
       state.mostSpentCategory = action.payload.name || 'None yet!'
       state.mostSpentCategorySpending = action.payload.total || 0
       state.isLoading = false


### PR DESCRIPTION
* previously both endpoints were returning a field called `total` so it broke the summary on the dashboard
* also fixes it so the items are still used from the store in the uploaded page